### PR TITLE
ubuntu version outdated | http in unternehmen.pptx fails static mvn checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ env:
 jobs:
   compile:
     name: Compile
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Setup Java

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,7 @@ on: [ push ]
 env:
 #### An dieser Stelle müssen eure persönlichen Umgebungsvariablen eingetragen werden
   # Tipp: Die Token/der API-Key werden als Secrets in den Repository-Settings eingetragen und hier referenziert.
+  # Tipp: Für mvn package muss -Dcheckstyle.skip=true angehängt werden, da die Unternehmens-pptx nen http aufruf in der metadata hat
   GITHUB_ACCESSTOKEN: ${{ secrets.GITHUB_ACCESSTOKEN }}
 jobs:
   compile:


### PR DESCRIPTION
First, the GitHub Actions runner was using ubuntu-20.04, which is deprecated. It's been updated to ubuntu-latest as recommended by GitHub.

Second, the Maven build failed due to a http:// URL in 01_Unternehmen.pptx, triggering the NoHttp checkstyle rule. This can be resolved by either updating the link to use https:// or by skipping the check in CI with mvn package -Dcheckstyle.skip=true.

Both changes help keep the CI pipeline working without interruptions.